### PR TITLE
Enhance .gitattributes with comprehensive .NET configurations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,35 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# C# source files
+*.cs text diff=csharp eol=lf
+*.csx text diff=csharp eol=lf
+
+# Visual Studio solution and project files
+*.sln text eol=crlf
+*.csproj text eol=lf
+*.vbproj text eol=lf
+*.vcxproj text eol=lf
+*.vcxproj.filters text eol=lf
+*.proj text eol=lf
+*.projitems text eol=lf
+*.shproj text eol=lf
+*.props text eol=lf
+*.targets text eol=lf
+
+# .NET configuration files
+*.config text eol=lf
+*.json text eol=lf
+*.xml text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+*.markdown text eol=lf
+
 # Shell scripts should always use LF line endings
 *.sh text eol=lf
+*.bash text eol=lf
 
 # PowerShell scripts should use CRLF line endings
 *.ps1 text eol=crlf
@@ -10,3 +37,54 @@
 # Windows batch files should use CRLF line endings
 *.bat text eol=crlf
 *.cmd text eol=crlf
+
+# Docker files
+Dockerfile text eol=lf
+*.dockerfile text eol=lf
+docker-compose*.yml text eol=lf
+
+# YAML files
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Build scripts
+*.cake text eol=lf
+*.msbuild text eol=lf
+
+# Git files
+.gitattributes text eol=lf
+.gitignore text eol=lf
+.gitmodules text eol=lf
+
+# Binary files - .NET assemblies and symbols
+*.dll binary
+*.exe binary
+*.pdb binary
+*.snk binary
+*.pfx binary
+
+# Images
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+
+# Archives
+*.zip binary
+*.7z binary
+*.gz binary
+*.tar binary
+*.nupkg binary
+
+# Fonts
+*.ttf binary
+*.eot binary
+*.woff binary
+*.woff2 binary
+
+# Linguist settings - proper language detection
+*.cs linguist-language=C#
+*.csproj linguist-language=XML linguist-generated=false
+*.sln linguist-language=Text linguist-generated=true


### PR DESCRIPTION
## Summary

Adds comprehensive `.gitattributes` rules for consistent file handling across Windows, Linux, and macOS development environments.

### Changes

- ✅ **C# Source Files**: Added `diff=csharp` for better diff output and enforced LF line endings
- ✅ **Visual Studio Files**: Configured appropriate line endings (.sln uses CRLF, project files use LF)
- ✅ **.NET Configuration**: Set LF line endings for .json, .xml, .config files
- ✅ **Documentation**: Standardized LF line endings for .md, .txt files
- ✅ **Docker Files**: Enforced LF line endings for Dockerfiles and docker-compose files
- ✅ **YAML Files**: Set LF line endings for .yml and .yaml files
- ✅ **Binary Files**: Explicitly marked assemblies, images, archives, and fonts as binary
- ✅ **Linguist Settings**: Improved GitHub language detection for C# and project files

### Benefits

- 🔄 **Cross-platform consistency**: Prevents line ending issues between Windows and Unix systems
- 🎯 **Better diffs**: C# diffs use language-aware diff driver
- 📊 **Accurate language detection**: Linguist correctly identifies C# as primary language
- 🚫 **No binary diffs**: Binary files properly marked to prevent meaningless diffs
- ✅ **Build reliability**: Consistent line endings prevent script execution issues

### Technical Details

**Line Ending Strategy:**
- LF (Unix): C# source, project files, scripts, configs, docs
- CRLF (Windows): Solution files (.sln), PowerShell scripts, batch files
- Binary: Assemblies, images, archives, fonts, NuGet packages

**Linguist Configuration:**
- C# source files: Explicitly marked as C# language
- Project files (.csproj): Marked as XML, not generated
- Solution files (.sln): Marked as generated (excluded from stats)

### Testing

- ✅ Validated .gitattributes syntax
- ✅ Confirmed no conflicts with master
- ✅ Aligns with existing line ending normalization from commit 694e59c

### Files Changed

- `.gitattributes` - Added 78 lines of comprehensive file handling rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>